### PR TITLE
Remove multicluster-engine, remove subscriptions from industrial-edge…

### DIFF
--- a/ci-triggers/ansible-edge-gitops.yaml
+++ b/ci-triggers/ansible-edge-gitops.yaml
@@ -37,5 +37,5 @@ triggers:
     buildType: stable
 
   subscriptions:
-  - name: gitops
-    branch: main
+  - name: none
+    branch: none

--- a/ci-triggers/industrial-edge.yaml
+++ b/ci-triggers/industrial-edge.yaml
@@ -37,7 +37,5 @@ triggers:
     buildType: stable
 
   subscriptions:
-  - name: gitops
-    branch: main
-  - name: rhacm
-    branch: main
+  - name: none
+    branch: none

--- a/ci-triggers/multicloud-gitops.yaml
+++ b/ci-triggers/multicloud-gitops.yaml
@@ -39,5 +39,3 @@ triggers:
     branch: main
   - name: rhacm
     branch: main
-  - name: multicluster_engine
-    branch: main

--- a/ci-triggers/multicluster-devsecops.yaml
+++ b/ci-triggers/multicluster-devsecops.yaml
@@ -34,8 +34,6 @@ triggers:
     branch: main
   - name: rhacm
     branch: main
-  - name: multicluster_engine
-    branch: main
   - name: odf
     branch: main
   - name: rhacs


### PR DESCRIPTION
… and ansible-edge-gitops

Removing multicluster-engine, at least temporarily while we figure out if/how to test.
Removing all subs from industrial-edge and ansible-edge-gitops until support is added for those patterns - this will reduce the noise in our CI slack channel.