### PR TITLE
Drop 4.10 from CI

### DIFF
--- a/ci-triggers/ansible-edge-gitops.yaml
+++ b/ci-triggers/ansible-edge-gitops.yaml
@@ -12,7 +12,6 @@ triggers:
     versions:
     - '4.12'
     - '4.11'
-    - '4.10'
 
   openshift:
   - version: '4.13'
@@ -26,11 +25,6 @@ triggers:
       - aws
     buildType: stable
   - version: '4.11'
-    branch: 'v1.2'
-    platforms:
-      - aws
-    buildType: stable
-  - version: '4.10'
     branch: 'v1.2'
     platforms:
       - aws

--- a/ci-triggers/industrial-edge.yaml
+++ b/ci-triggers/industrial-edge.yaml
@@ -12,7 +12,6 @@ triggers:
     versions:
     - '4.12'
     - '4.11'
-    - '4.10'
 
   openshift:
   - version: '4.13'
@@ -29,11 +28,6 @@ triggers:
     branch: 'v2.3'
     platforms:
       - gcp
-    buildType: stable
-  - version: '4.10'
-    branch: 'v2.3'
-    platforms:
-      - azure
     buildType: stable
 
   subscriptions:

--- a/ci-triggers/medical-diagnosis.yaml
+++ b/ci-triggers/medical-diagnosis.yaml
@@ -11,7 +11,6 @@ triggers:
   - name: 'v2.5'
     versions:
     - '4.12'
-    - '4.10'
     - '4.11'
 
   openshift:
@@ -30,11 +29,6 @@ triggers:
     branch: 'v2.5'
     platforms:
       - aws
-  - version: '4.10'
-    branch: 'v2.5'
-    platforms:
-      - gcp
-    buildType: stable
 
   github:
     - version: '4.11'

--- a/ci-triggers/multicloud-gitops.yaml
+++ b/ci-triggers/multicloud-gitops.yaml
@@ -11,7 +11,6 @@ triggers:
     - '4.13'
     - '4.12'
     - '4.11'
-    - '4.10'
 
   openshift:
   - version: '4.14'
@@ -33,11 +32,6 @@ triggers:
     branch: main
     platforms:
       - gcp
-    buildType: stable
-  - version: '4.10'
-    branch: main
-    platforms:
-      - azure
     buildType: stable
 
   subscriptions:


### PR DESCRIPTION
It's out of support officially since Sep 10, 2023.
https://access.redhat.com/support/policy/updates/openshift
