### PR TITLE
Drop 4.11 from CI

### DIFF
--- a/ci-triggers/ansible-edge-gitops.yaml
+++ b/ci-triggers/ansible-edge-gitops.yaml
@@ -13,7 +13,6 @@ triggers:
     versions:
     - '4.13'
     - '4.12'
-    - '4.11'
 
   openshift:
   - version: '4.14'
@@ -27,11 +26,6 @@ triggers:
       - aws
     buildType: stable
   - version: '4.12'
-    branch: 'v1.2'
-    platforms:
-      - aws
-    buildType: stable
-  - version: '4.11'
     branch: 'v1.2'
     platforms:
       - aws

--- a/ci-triggers/industrial-edge.yaml
+++ b/ci-triggers/industrial-edge.yaml
@@ -11,7 +11,6 @@ triggers:
     - '4.14'
     - '4.13'
     - '4.12'
-    - '4.11'
 
   openshift:
   - version: '4.14'
@@ -28,11 +27,6 @@ triggers:
     branch: 'main'
     platforms:
       - aws
-    buildType: stable
-  - version: '4.11'
-    branch: 'main'
-    platforms:
-      - gcp
     buildType: stable
 
   subscriptions:

--- a/ci-triggers/medical-diagnosis.yaml
+++ b/ci-triggers/medical-diagnosis.yaml
@@ -13,7 +13,6 @@ triggers:
     versions:
     - '4.13'
     - '4.12'
-    - '4.11'
 
   openshift:
   - version: '4.14'
@@ -31,16 +30,6 @@ triggers:
     platforms:
       - azure
     buildType: stable
-  - version: '4.11'
-    buildType: stable
-    branch: 'v2.6'
-    platforms:
-      - aws
-
-  github:
-    - version: '4.11'
-      platforms:
-        - azure
 
   subscriptions:
   - name: gitops

--- a/ci-triggers/multicloud-gitops.yaml
+++ b/ci-triggers/multicloud-gitops.yaml
@@ -11,7 +11,6 @@ triggers:
     - '4.14'
     - '4.13'
     - '4.12'
-    - '4.11'
 
   openshift:
   - version: '4.14'
@@ -28,11 +27,6 @@ triggers:
     branch: main
     platforms:
       - azure
-    buildType: stable
-  - version: '4.11'
-    branch: main
-    platforms:
-      - gcp
     buildType: stable
 
   subscriptions:

--- a/ci-triggers/multicluster-devsecops.yaml
+++ b/ci-triggers/multicluster-devsecops.yaml
@@ -12,7 +12,6 @@ triggers:
     - '4.14'
     - '4.13'
     - '4.12'
-    - '4.11'
 
   openshift:
   - version: '4.14'
@@ -29,11 +28,6 @@ triggers:
     branch: main
     platforms:
       - gcp
-    buildType: stable
-  - version: '4.11'
-    branch: main
-    platforms:
-      - azure
     buildType: stable
 
   subscriptions:

--- a/ci-triggers/retail.yaml
+++ b/ci-triggers/retail.yaml
@@ -14,7 +14,6 @@ triggers:
     versions:
     - '4.13'
     - '4.12'
-    - '4.11'
 
   openshift:
   - version: '4.14'
@@ -30,12 +29,6 @@ triggers:
     buildType: stable
 
   - version: '4.12'
-    branch: v1.1
-    platforms:
-      - aws
-    buildType: stable
-
-  - version: '4.11'
     branch: v1.1
     platforms:
       - aws


### PR DESCRIPTION
Its out of support date is 10 Feb, 2024
https://access.redhat.com/support/policy/updates/openshift

Let's drop it so we can up the gitops default on all the patterns.
4.12 has gitops-1.11 so we can switch to that.
