### PR TITLE
Bump Ansible Edge testing to branch 1.3

### DIFF
--- a/ci-triggers/ansible-edge-gitops.yaml
+++ b/ci-triggers/ansible-edge-gitops.yaml
@@ -9,7 +9,7 @@ triggers:
   - name: main
     versions:
     - '4.14'
-  - name: 'v1.2'
+  - name: 'v1.3'
     versions:
     - '4.13'
     - '4.12'
@@ -21,12 +21,12 @@ triggers:
       - aws
     buildType: stable
   - version: '4.13'
-    branch: 'v1.2'
+    branch: 'v1.3'
     platforms:
       - aws
     buildType: stable
   - version: '4.12'
-    branch: 'v1.2'
+    branch: 'v1.3'
     platforms:
       - aws
     buildType: stable


### PR DESCRIPTION
With the successful run on main for 4.14, the other versions should be ready to run against branch v1.3 (which is currently level with main)