### PR TITLE
avoid hardcoded S3 bucket name (which btw is no longer valid)

### DIFF
--- a/aws-tools/s3-sync-buckets.py
+++ b/aws-tools/s3-sync-buckets.py
@@ -77,7 +77,7 @@ def sync_buckets(s3, source_bucket, target_bucket):
     # Iterate All Objects in Your S3 Bucket Over the for Loop
     for file in srcbucket.objects.all():
       copy_source = {
-        'Bucket': 'com.validated-patterns.xray-source',
+        'Bucket': source_bucket,
         'Key': file.key
       }
       


### PR DESCRIPTION
The S3 bucket name containing xray images is no longer called `com.validated-patterns.xray-source`, but rather `validated-patterns-md-xray`. As it could change again in the future, it would be best to not hardcode anything but use the existing command line argument instead. 