### PR TITLE
Drop jobs for IE on OCP > 4.13

### DIFF
--- a/ci-triggers/industrial-edge.yaml
+++ b/ci-triggers/industrial-edge.yaml
@@ -8,22 +8,10 @@ triggers:
   branches:
   - name: main
     versions:
-    - '4.15'
-    - '4.14'
     - '4.13'
     - '4.12'
 
   openshift:
-  - version: '4.15'
-    branch: main
-    platforms:
-      - aws
-    buildType: stable
-  - version: '4.14'
-    branch: main
-    platforms:
-      - gcp
-    buildType: stable
   - version: '4.13'
     branch: main
     platforms:


### PR DESCRIPTION
No point in running them since seldon is not available for OCP > 4.13:
https://github.com/redhat-openshift-ecosystem/certified-operators/blob/main/operators/seldon-operator-certified/1.16.0-0/metadata/annotations.yaml#L12
