### PR TITLE
Rework homepage-container

### DIFF
--- a/homepage-container/Containerfile
+++ b/homepage-container/Containerfile
@@ -1,8 +1,23 @@
-FROM --platform=$BUILDPLATFORM alpine:3.17 as build
+FROM quay.io/centos/centos:stream9 AS builder
 
-RUN apk add --no-cache hugo build-base gcc bash cmake git gcompat curl ruby
+# Default is set in Makefile
+ARG HUGO_VERSION
+
+# Temporary hack because extras-common repo seems to be busted
+RUN dnf --disablerepo=extras-common install -y 'dnf-command(config-manager)' && dnf config-manager --set-disabled extras-common && dnf clean all
+
+RUN dnf install -y --allowerasing git-core golang ruby curl cmake gcc && dnf clean all
+RUN mkdir -p /tmp/hugodl && cd /tmp/hugodl && \
+  curl -L -O "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.tar.gz" && \
+  tar xf "hugo_${HUGO_VERSION}_linux-amd64.tar.gz" && \
+  mv hugo /usr/local/bin/hugo && \
+  chmod 0755 /usr/local/bin/hugo && \
+  rm -rf /tmp/hugodl
+
 RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
-RUN gem install bundler && echo -e 'source "https://rubygems.org"\ngem "asciidoctor"\ngem "rouge"\n' > Gemfile && bundle install
+RUN mkdir -p /tmp/rubybuild && cd /tmp/rubybuild && \
+  gem install bundler && echo -e 'source "https://rubygems.org"\ngem "asciidoctor"\ngem "rouge"\n' > Gemfile && \
+  bundle install
 EXPOSE 4000
 
 WORKDIR /site

--- a/homepage-container/Makefile
+++ b/homepage-container/Makefile
@@ -1,3 +1,5 @@
+HUGO_VERSION ?= 0.122.0
+
 ##@ Container build tasks
 .PHONY: help
 help: ## This help message
@@ -6,7 +8,7 @@ help: ## This help message
 .PHONY: build
 build: ## Build the container locally
 	@echo "Building the homepage container"
-	buildah bud --format docker -f Containerfile -t homepage-container
+	buildah bud --format docker -f Containerfile -t homepage-container --build-arg HUGO_VERSION=$(HUGO_VERSION)
 
 .PHONY: upload
 upload: build ## Builds and then uploads the container to quay.io/hybridcloudpatterns/homepage-container:latest
@@ -16,3 +18,12 @@ upload: build ## Builds and then uploads the container to quay.io/hybridcloudpat
 .PHONY: run
 run: ## Run the local container
 	podman run -it --rm --net=host localhost/homepage-container:latest
+
+.PHONY: super-linter
+super-linter: ## Runs super linter locally
+	podman run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true	\
+					-e VALIDATE_DOCKERFILE_HADOLINT=true \
+					$(DISABLE_LINTERS) \
+					-v $(PWD):/tmp/lint:rw,z \
+					-w /tmp/lint \
+					docker.io/github/super-linter:slim-v5

--- a/homepage-container/README.md
+++ b/homepage-container/README.md
@@ -12,8 +12,10 @@ make serve
 ## Build the container
 
 ```shell
-buildah bud --format docker -f Containerfile -t homepage-container
+make build
 ```
+
+Optionally you can set the Hugo version via the `HUGO_VERSION` env variable.
 
 ## Run the built container
 


### PR DESCRIPTION
This way we can pick and choose our hugo version.
While we're at it let's move to CentOS

Tested via:

    make build
    cd <docs repo>
    export HOMEPAGE_CONTAINER=localhost/homepage-container:latest
    make serve
