### PR TITLE
Docs site requires the extended version of hugo

### DIFF
--- a/homepage-container/Containerfile
+++ b/homepage-container/Containerfile
@@ -8,8 +8,8 @@ RUN dnf --disablerepo=extras-common install -y 'dnf-command(config-manager)' && 
 
 RUN dnf install -y --allowerasing git-core golang ruby curl cmake gcc && dnf clean all
 RUN mkdir -p /tmp/hugodl && cd /tmp/hugodl && \
-  curl -L -O "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.tar.gz" && \
-  tar xf "hugo_${HUGO_VERSION}_linux-amd64.tar.gz" && \
+  curl -L -O "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" && \
+  tar xf "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" && \
   mv hugo /usr/local/bin/hugo && \
   chmod 0755 /usr/local/bin/hugo && \
   rm -rf /tmp/hugodl


### PR DESCRIPTION
- Updated the Containerfile to download install the extended version of hugo.
- Certain plugins/capabilities (SSCS) require extended version