### PR TITLE
Add trigger CI file for emergingdd

### DIFF
--- a/ci-triggers/emergingdd.yaml
+++ b/ci-triggers/emergingdd.yaml
@@ -1,0 +1,22 @@
+shortName: emergingdd
+fullName: EmergingDiseaseDetection
+repo: https://github.com/validatedpatterns/emerging-disease-detection
+webHookName: ''
+owners:
+  - jrickard
+triggers:
+  branches:
+  - name: main
+    versions:
+    - '4.13'
+
+  openshift:
+  - version: '4.13'
+    branch: main
+    platforms:
+      - gcp
+    buildType: stable
+
+  subscriptions:
+  - name: none
+    branch: none


### PR DESCRIPTION
This is the same Openshift version and platform that we used for image-classification.
Not sure if we want to update this or not.