### PR TITLE
Refactor Containerfile to use latest UBI base image

### DIFF
--- a/homepage-container/Containerfile
+++ b/homepage-container/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9 AS builder
+FROM registry.access.redhat.com/ubi10/ubi-minimal
 
 # Default is set in Makefile
 ARG HUGO_VERSION="0.133.1"
@@ -6,20 +6,17 @@ ARG TARGETARCH
 ARG ALTTARGETARCH
 
 # Temporary hack because extras-common repo seems to be busted
-RUN dnf --disablerepo=extras-common install -y 'dnf-command(config-manager)' && dnf config-manager --set-disabled extras-common && dnf clean all
+RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 \
+    curl tar gzip ruby ruby-devel gcc gcc-c++ make \
+ && curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz" \
+    | tar -xzC /usr/local/bin hugo \
+ && chmod +x /usr/local/bin/hugo \
+ && curl -fsSL https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin \
+ && gem install --no-document asciidoctor rouge \
+ && microdnf remove -y ruby-devel gcc gcc-c++ make \
+ && microdnf clean all \
+ && rm -rf /var/cache/yum
 
-RUN dnf install -y --allowerasing git-core golang ruby curl cmake gcc && dnf clean all
-RUN mkdir -p /tmp/hugodl && cd /tmp/hugodl && \
-  curl -L -O "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz" && \
-  tar xf "hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz" && \
-  mv hugo /usr/local/bin/hugo && \
-  chmod 0755 /usr/local/bin/hugo && \
-  rm -rf /tmp/hugodl
-
-RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
-RUN mkdir -p /tmp/rubybuild && cd /tmp/rubybuild && \
-  gem install bundler && echo -e 'source "https://rubygems.org"\ngem "asciidoctor"\ngem "rouge"\n' > Gemfile && \
-  bundle install
 EXPOSE 4000
 
 WORKDIR /site


### PR DESCRIPTION
Uses recommended UBI 10 minimal image for security and size savings

| Image                                                      | Tag     | Image ID      | Created         | Size  |
|-----------------------------------------------------------:|:--------|:--------------|:----------------|:------|
| localhost/ubi10-homepage-container                         | latest  | afde5ae814c0  | 6 seconds ago   | 298 MB|
| quay.io/hybridcloudpatterns/homepage-container            | main    | f41b73d360c1  | 2 months ago    | 827 MB|
| quay.io/hybridcloudpatterns/homepage-container            | latest  | 767d8ebbe6ac  | 10 months ago   | 769 MB|

I tested the image for building docs, but couldn't test it locally though using the `make build` command in this repo.