### PR TITLE
Update Containerfile to include 'zip' in the installation dependencies

### DIFF
--- a/homepage-container/Containerfile
+++ b/homepage-container/Containerfile
@@ -7,7 +7,7 @@ ARG ALTTARGETARCH
 
 # Temporary hack because extras-common repo seems to be busted
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 \
-    curl tar gzip ruby ruby-devel gcc gcc-c++ make \
+    curl tar gzip zip ruby ruby-devel gcc gcc-c++ make \
  && curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz" \
     | tar -xzC /usr/local/bin hugo \
  && chmod +x /usr/local/bin/hugo \


### PR DESCRIPTION
Netlify-CLI is a Node-based app, which would require NodeJS and NPM for installation, so I have updated [the build steps](https://github.com/openshift/release/pull/68582/files#diff-5b8a6634dead0c9db6e35c184a951c3d1c4147538859d6c43f6561dcd16e2919) to use Netlify API instead.

Netlify API suggests uploading a ZIP digest for the site. SO I've added the `zip` package to our image.